### PR TITLE
feat(navigation): add tabs and dots

### DIFF
--- a/navigation/dots.md
+++ b/navigation/dots.md
@@ -1,0 +1,9 @@
+# Dots
+
+```html live
+<div class="flex justify-center">
+  <button class="m-1 p-1 rounded-full font-medium bg-gray-700 cursor-pointer focus:bg-gray-900 focus:outline-none"></button>
+  <button class="m-1 p-1 rounded-full font-medium bg-gray-400 cursor-pointer focus:bg-gray-900 focus:outline-none"></button>
+  <button class="m-1 p-1 rounded-full font-medium bg-gray-400 cursor-pointer focus:bg-gray-900 focus:outline-none"></button>
+</div>
+```

--- a/navigation/tabs.md
+++ b/navigation/tabs.md
@@ -1,0 +1,19 @@
+# Tabs
+
+```html live
+<div class="flex justify-center">
+  <button class="flex-grow px-4 py-1 text-sm font-medium border-b border-gray-600 cursor-pointer focus:border-gray-900 focus:outline-none">LEFT</button>
+  <button class="flex-grow px-4 py-1 text-sm font-medium border-b cursor-pointer focus:border-gray-900 focus:outline-none">CENTER</button>
+  <button class="flex-grow px-4 py-1 text-sm font-medium border-b cursor-pointer focus:border-gray-900 focus:outline-none">RIGHT</button>
+</div>
+```
+
+```html live
+<div class="flex justify-center">
+  <button class="flex-grow px-4 py-1 text-sm font-medium border-b border-gray-600 cursor-pointer focus:border-gray-900 focus:outline-none">1</button>
+  <button class="flex-grow px-4 py-1 text-sm font-medium border-b cursor-pointer focus:border-gray-900 focus:outline-none">2</button>
+  <button class="flex-grow px-4 py-1 text-sm font-medium border-b cursor-pointer focus:border-gray-900 focus:outline-none">3</button>
+  <button class="flex-grow px-4 py-1 text-sm font-medium border-b cursor-pointer focus:border-gray-900 focus:outline-none">4</button>
+  <button class="flex-grow px-4 py-1 text-sm font-medium border-b cursor-pointer focus:border-gray-900 focus:outline-none">5</button>
+</div>
+```


### PR DESCRIPTION
Add Navigation components from the design system. Used focus pseudo-class as a demonstration for selected tab/dot, that highlight class will probably be controlled by a state, store or router variable in real use cases

## Tabs

<img width="668" alt="Screen Shot 2020-04-10 at 22 45 14" src="https://user-images.githubusercontent.com/16889233/79033548-f8e2dd80-7b7c-11ea-9d42-8dfb904e06b3.png">

<img width="668" alt="Screen Shot 2020-04-10 at 22 43 51" src="https://user-images.githubusercontent.com/16889233/79033546-f7b1b080-7b7c-11ea-9cfb-47fbabb84333.png">

## Dots

<img width="668" alt="Screen Shot 2020-04-10 at 22 44 22" src="https://user-images.githubusercontent.com/16889233/79033547-f8e2dd80-7b7c-11ea-99c4-4bc4f459dc07.png">



