### PR TITLE
fix(file-inputs): change shrine component created callback to mounted

### DIFF
--- a/form-elements/file-inputs.md
+++ b/form-elements/file-inputs.md
@@ -166,7 +166,7 @@ export default {
       previewSrc: null,
     };
   },
-  created() {
+  mounted() {
     const container = this.$refs.container;
 
     const uppy = createUppyUploader({


### PR DESCRIPTION
In `created` the component html is not yet present. Because of this the `this.$refs.container` was not found and the Uppy button wasn't showing in the Shrine example.

Hook was changed to `mounted`